### PR TITLE
Fill profileId from $config; PHP <=5.3 compatibility

### DIFF
--- a/AmazonAdvertisingApi/Client.php
+++ b/AmazonAdvertisingApi/Client.php
@@ -38,6 +38,12 @@ class Client
         $this->applicationVersion = $this->versionStrings["applicationVersion"];
         $this->userAgent = "AdvertisingAPI PHP Client Library v{$this->applicationVersion}";
 
+		if (!empty($config["profileId"])) {
+			/* Populate profileId if it persists in the config and unset it to pass the _validateConfig */
+			$this->profileId = $config['profileId'];
+			unset($config["profileId"]);
+		}
+
         $this->_validateConfig($config);
         $this->_validateConfigParameters();
         $this->_setEndpoints();
@@ -449,7 +455,8 @@ class Client
             $json = json_decode($response, true);
             if (!is_null($json)) {
                 if (array_key_exists("requestId", $json)) {
-                    $requestId = json_decode($response, true)["requestId"];
+                    $request = json_decode($response, true);
+					$requestId = $request["requestId"];
                 }
             }
             return array("success" => false,


### PR DESCRIPTION
Populating Client->profileId if passed in $config array at initialization for convenience.
Small change for PHP <=5.3 compatibility, which doesn't support array dereference the result of a function or method call directly.
